### PR TITLE
Vagrant Automatic Dev Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 # http://github.com/RailsApps/rails-composer/issues
 #----------------------------------------------------------------------------
 
+# vagrant virtual machine
+.vagrant
+
+# oracle-instantclient rpm packages
+*.rpm
+
 # bundler state
 /.bundle
 /vendor/bundle/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "hashicorp/precise64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/home/vagrant/wrektranet", create: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    # Kill 'stdin is not a tty' error messages
+    sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile
+    sudo chmod +x /home/vagrant/wrektranet/bootstrap.sh
+    /home/vagrant/wrektranet/bootstrap.sh
+    sudo chmod -x /home/vagrant/wrektranet/bootstrap.sh
+  SHELL
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -e
+
+# Boostraps a Wrektranet dev box. This is primarily for use with Vagrant on a
+# Ubuntu box, could be used on any real Ubuntu box, in theory.
+#
+# REQUIRES:
+# Download of the "Oracle InstantClient RPM files for Linux x86-64" from
+# <http://www.oracle.com/technetwork/topics/linuxx86-64soft-092277.html>.
+# These files are: basic, sqlplus, and SDK (listed as 'devel' for the RPM).
+# Download those files, and put them in the top-level Wrektranet git directory.
+#
+# Here's a rough set of steps that will be taken to get everything provisioned:
+#   01. Setup a simple directory structure.
+#   02. Update apt-get
+#   03. Install needed mysql packages with apt-get
+#   04. Convert the RPM files to DEB files, and install them.
+#   05. Setup ORACLE environment variables and symlinks
+#   06. Install RVM
+#   07. Install Node.js
+#   08. Download the correct ruby version with RVM
+#   09. Install bundler
+#   10. Install project dependencies
+#
+# That should settle everything. Rails is downloaded as a Gem dependency, so
+# no worries about that. Let's get started.
+
+
+
+
+cd /home/vagrant
+
+# 1. Move files around, get the version of the oracle client
+mkdir oracle_raws/
+cd wrektranet/
+for file in $(ls | grep 'oracle-instantclient');
+    do cp $file /home/vagrant/oracle_raws/;
+done
+
+cd /home/vagrant/oracle_raws
+ORACLE_CLIENT_VERSION=$(ls |
+                        grep 'oracle' |
+                        sed 's/oracle-instantclient\([0-9]*.[0-9]*\).*/\1/p' |
+                        head -n1)
+cd /home/vagrant
+
+# 2. Update apt-get
+printf "Updating apt-get..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes upgrade
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes dist-upgrade
+printf "done\n"
+
+# 3. Install neeeded mysql packages
+printf "Installing libaio1..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install libaio1
+printf "done\n"
+
+printf "Installing mysql-server..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server
+printf "done\n"
+
+# 4. Convert/install RPM files
+printf "Installing alien..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install alien
+printf "done\n"
+cd oracle_raws/
+for file in $(ls);
+    do printf "Converting $file to .deb file...";
+    sudo alien -i $file > /dev/null;
+    printf "done\n";
+done
+
+# 5. Setup Oracle env files and symlinks
+echo "
+export ORACLE_HOME=/usr/lib/oracle/$ORACLE_CLIENT_VERSION/client64
+export PATH=\$PATH:\$ORACLE_HOME/bins
+export LD_LIBRARY_PATH=/usr/lib/oracle/$ORACLE_CLIENT_VERSION/client64/lib/\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}" > oracle.sh
+
+sudo mv oracle.sh /etc/profile.d/oracle.sh
+sudo chmod o+r /etc/profile.d/oracle.sh
+sudo ln -s /usr/include/oracle/$ORACLE_CLIENT_VERSION/client64 /usr/lib/oracle/$ORACLE_CLIENT_VERSION/client64/include
+source /etc/profile.d/oracle.sh
+
+
+# 6. Install RVM
+printf "Installing curl..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install curl
+printf "done\n"
+
+RVM_KEY=409B6B1796C275462A1703113804BB82D39DC0E3
+gpg --keyserver hkp://keys.gnupg.net --recv-keys $RVM_KEY > /dev/null
+
+printf "Installing RVM..."
+curl -sSL https://get.rvm.io | bash -s stable --ruby
+printf "done\n"
+source ~/.rvm/scripts/rvm
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get autoremove --assume-yes
+
+# 7. Install Node.js
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+printf "Installing nodejs..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install -y nodejs
+printf "done\n"
+
+# 8. Download project ruby version (if there's an automated way for RVM to do
+# this, go ahead and replace what's here with that).
+cd /home/vagrant/wrektranet
+RUBY_VERSION=$(cat Gemfile |
+               grep "^ruby" |
+               sed "s/ruby '\([0-9]*\.[0-9]*\.[0-9]*\)'/\1/")
+NANO_VERSION=p247
+#FULL_VERSION=ruby-$RUBY_VERSION-$NANO_VERSION
+printf "Installing $RUBY_VERSION..."
+rvm install $RUBY_VERSION > /dev/null
+printf "done\n"
+rvm --default use 2.0.0
+
+# 9. Install bundler and git
+printf "Installing git..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install git
+printf "dont\n"
+
+printf "Installing bundler..."
+gem install bundler
+printf "done\n"
+
+# 10. Install project dependencies
+printf "Installing libmysqlclient-dev..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install libmysqlclient-dev
+printf "done\n"
+printf "Running bundle install..."
+bundle install
+printf "done\n"
+
+exit 0

--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   encoding: utf8
   pool: 5
   host: localhost
-  username: travis
+  username: root
 
 production_defaults: &production_defaults
   adapter: mysql2
@@ -34,12 +34,12 @@ oracle_legacy_development:
 
 test: &test
   database: wrek_test
-  username: travis
+  username: root
   <<: *defaults
 
 staff_legacy_test:
   database: staff_legacy_test
-  username: travis
+  username: root
   <<: *defaults
 
 # Production


### PR DESCRIPTION
Due to the number of dependencies, Oracle driver requirements, and
general Ruby/RVM foolishness, setting up a dev environment was
difficult. This PR introduces a Vagrant configuration file that
automatically sets-up a dev environment, ready to be worked on.

Additionally, it gives us a canonical and quick way to make
Wrektranet2 platforms, if we ever need to redeploy from scratch.

This is also to replace the former Vagrant instructions for platform-
independent setup, which has been outdated for several years now.
